### PR TITLE
Fix object-tools to allow for more than one link

### DIFF
--- a/bootstrap_admin/static/admin/css/changelists.css
+++ b/bootstrap_admin/static/admin/css/changelists.css
@@ -7,6 +7,13 @@
     margin-left: 15px;
     margin-top: 15px;
 }
+.object-tools li {
+    float: left;
+    margin-left: 5px;
+}
+.object-tools:after {
+    clear: both;
+}
 #changelist .nav-collapse .nav > li.active > a,
 #changelist .nav-collapse .dropdown-menu li.active a{
     color: #fff;

--- a/bootstrap_admin/templates/admin/change_list.html
+++ b/bootstrap_admin/templates/admin/change_list.html
@@ -69,6 +69,7 @@
           </li>
         {% endblock %}
       </ul>
+      <script type="text/javascript">django.jQuery("ul.object-tools li a").addClass("btn");</script>
     {% endif %}
   {% endblock %}
   <div id="content-main">


### PR DESCRIPTION
First off, thanks for the best django admin bootstrap app I could find. Really nicely done. :)

We use django-reversion to track object changes and it adds a link to the `object-tools` section of the changelist. Currently it looks like this:

![Screen Shot 2013-01-23 at 9 55 51 PM](https://f.cloud.github.com/assets/1594130/92445/acc19338-65d1-11e2-8244-c2cf6c52b566.png)

This pull request adds the necessary css to make the buttons align horizontally and also monkey patches the `btn` class onto all the links, because django-reversion doesn't add it.

![Screen Shot 2013-01-23 at 9 56 17 PM](https://f.cloud.github.com/assets/1594130/92446/b11151c6-65d1-11e2-9cc2-e49d451b017e.png)
