### PR TITLE
Add .sortoptions styling

### DIFF
--- a/bootstrap_admin/static/admin/css/changelists.css
+++ b/bootstrap_admin/static/admin/css/changelists.css
@@ -132,6 +132,24 @@
 .datetime input{
     width: 80px;
 }
+.sortoptions a.sortremove:hover{
+    text-decoration: none;
+}
+.sortoptions a.sortremove:after{
+    content: "\2717";
+}
+.sortoptions a.toggle:hover{
+    text-decoration: none;
+}
+.sortoptions a.toggle.ascending:after{
+    content: "\25BC";
+}
+.sortoptions a.toggle.descending:after{
+    content: "\25B2";
+}
+.sortoptions .sortpriority{
+    display: none;
+}
 @media (max-width: 979px) {
     .nav-collapse .pull-left,
     .nav-collapse .pull-right{


### PR DESCRIPTION
Hi,

Thanks for this great admin skin! I made a small improvement by adding styling for the .sortoptions elements:

![sortoptions](https://f.cloud.github.com/assets/1597703/1590734/7569df56-5295-11e3-8b11-0bd826b397bf.png)

Tested in IE8, IE9, Latest FF and Chrome.

Regards,

Erik-Jan
