### PR TITLE
fix bug that displays only the field.label_tag when using HiddenInput widget

### DIFF
--- a/bootstrap_admin/templates/admin/includes/field.html
+++ b/bootstrap_admin/templates/admin/includes/field.html
@@ -37,7 +37,10 @@
                             {% endif %}
                         </div>
                         {% else %}
+                        {# only show the label for visible fields #}
+                        {% if not field.field.is_hidden %}
                         <div class="control-label">{{ field.label_tag }}</div>
+                        {% endif %}
                         <div class="controls">
                             {% if field.is_readonly %}
                                 <p>{{ field.contents|linebreaksbr }}</p>


### PR DESCRIPTION
when using HiddenInput widget django admin hides the field but shows the field's label (see the attached image). this is a fix for this behaviour.
![screen shot 2013-12-09 at 6 00 08 pm](https://f.cloud.github.com/assets/30587/1708687/cb016318-6112-11e3-9ad2-5d2b1361a7bd.png)
