### PR TITLE
fix #66 center calendar box caption

### DIFF
--- a/bootstrap_admin/static/admin/css/forms.css
+++ b/bootstrap_admin/static/admin/css/forms.css
@@ -432,6 +432,7 @@ p.datetime span.datetimeshortcuts {
 .calendarbox caption {
   margin-top: -17px;
   padding: 0 45px;
+  text-align: center;
 }
 .calendarbox .calendarnav-next {
   float: right;


### PR DESCRIPTION
Fixed https://github.com/douglasmiranda/django-admin-bootstrap/issues/66 the misaligned calendar box caption. It use to be aligned left. Here's what it looks like now:

![image](https://cloud.githubusercontent.com/assets/709616/6032867/4a1d7848-abc3-11e4-8a4e-c0501604d74c.png)
