### PR TITLE
Fixing import from Django js out of master branch

### DIFF
--- a/bootstrap_admin/templates/admin/change_form.html
+++ b/bootstrap_admin/templates/admin/change_form.html
@@ -86,7 +86,7 @@
             {% block admin_change_form_document_ready %}
               <script type="text/javascript"
                       id="django-admin-form-add-constants"
-                      src="{% static 'admin/js/change_form.js' %}"
+                      src="{% static 'change_form.js' %}"
                       {% if adminform and add %}
                           data-model-name="{{ opts.model_name }}"
                       {% endif %}>
@@ -144,7 +144,6 @@
         $('.vManyToManyRawIdAdminField, .vForeignKeyRawIdAdminField').addClass('form-control');
         $('.form-row input[type="checkbox"]').parent().addClass('checkbox');
         $('.radiolist li').addClass('radio');
-
         $('.form-expand').on('click', function () {
           $form_fields = $('.form-fields');
           $form_buttons = $('.form-buttons');

--- a/bootstrap_admin/templates/admin/popup_response.html
+++ b/bootstrap_admin/templates/admin/popup_response.html
@@ -1,11 +1,15 @@
-{% load i18n static %}<!DOCTYPE html>
+{% load i18n %}<!DOCTYPE html>
 <html>
   <head><title>{% trans 'Popup closing...' %}</title></head>
   <body>
-    <script type="text/javascript"
-            id="django-admin-popup-response-constants"
-            src="{% static "admin/js/popup_response.js" %}"
-            data-popup-response="{{ popup_response_data }}">
+    <script type="text/javascript">
+      {% if action == 'change' %}
+        opener.dismissChangeRelatedObjectPopup(window, "{{ value|escapejs }}", "{{ obj|escapejs }}", "{{ new_value|escapejs }}");
+      {% elif action == 'delete' %}
+        opener.dismissDeleteRelatedObjectPopup(window, "{{ value|escapejs }}");
+      {% else %}
+        opener.dismissAddRelatedObjectPopup(window, "{{ value|escapejs }}", "{{ obj|escapejs }}");
+      {% endif %}
     </script>
   </body>
 </html>

--- a/bootstrap_admin/templates/admin/prepopulated_fields_js.html
+++ b/bootstrap_admin/templates/admin/prepopulated_fields_js.html
@@ -1,6 +1,25 @@
-{% load l10n static %}
-<script type="text/javascript"
-        id="django-admin-prepopulated-fields-constants"
-        src="{% static "admin/js/prepopulate_init.js" %}"
-        data-prepopulated-fields="{{ prepopulated_fields_json }}">
+{% load l10n %}
+<script type="text/javascript">
+(function($) {
+    var field;
+{% for field in prepopulated_fields %}
+    field = {
+        id: '#{{ field.field.auto_id }}',
+        dependency_ids: [],
+        dependency_list: [],
+        maxLength: {{ field.field.field.max_length|default:"50"|unlocalize }},
+        allowUnicode: {{ field.field.field.allow_unicode|default:"false"|lower }}
+    };
+    {% for dependency in field.dependencies %}
+    field['dependency_ids'].push('#{{ dependency.auto_id }}');
+    field['dependency_list'].push('{{ dependency.name }}');
+    {% endfor %}
+    {% comment %}
+    Mark prepopulated fields in the main form and stacked inlines (.empty-form .form-row) and in tabular inlines (.empty-form.form-row)
+    {% endcomment %}
+    $('.empty-form .form-row .field-{{ field.field.name }}, .empty-form.form-row .field-{{ field.field.name }}').addClass('prepopulated_field');
+    $(field.id).data('dependency_list', field['dependency_list'])
+               .prepopulate(field['dependency_ids'], field.maxLength, field.allowUnicode);
+{% endfor %}
+})(django.jQuery);
 </script>


### PR DESCRIPTION
Hello, 

I'm pushing to resolve #98  for those who does not use Django from master branch.
Basically, the versions  branches does not has the following js files:

`admin/js/popup_response.js`
`admin/js/prepopulate_init.js`
`admin/js/change_form.js`

It's need to fix those imports.
You can see the [change_form.html](https://github.com/django/django/blob/1.9.8/django/contrib/admin/templates/admin/change_form.html) example.

ps other files:

[popup_response.html](https://github.com/django/django/blob/1.9.8/django/contrib/admin/templates/admin/change_form.html)
[prepopulated_fields_js.html](https://github.com/django/django/blob/1.9.8/django/contrib/admin/templates/admin/change_form.html)
