### PR TITLE
Make template_tags compatible with django 2.0

### DIFF
--- a/bootstrap_admin/templatetags/bootstrap_admin_template_tags.py
+++ b/bootstrap_admin/templatetags/bootstrap_admin_template_tags.py
@@ -1,7 +1,7 @@
 from django.contrib.admin import site
 from django.apps import apps
 from django.utils.text import capfirst
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.urls import reverse, NoReverseMatch
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 from django.conf import settings
@@ -65,7 +65,7 @@ def sidebar_menu_setting():
     return getattr(settings, 'BOOTSTRAP_ADMIN_SIDEBAR_MENU', True)
 
 
-@register.assignment_tag
+@register.simple_tag
 def display_sidebar_menu(has_filters=False):
     if has_filters:
         # Always display the menu in change_list.html


### PR DESCRIPTION
`django.core.urlresolvers` was moved to `django.urls`
`assigment_tag` is removed and `simple_tag` gains the same ability
(https://docs.djangoproject.com/en/2.0/releases/1.9/#deprecated-features-1-9)