### PR TITLE
Adds explicit supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,12 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     keywords='django,admin,skin,theme,bootstrap,responsive',
 )


### PR DESCRIPTION
Added explicit list of supported Python versions (implied by the support of Django 1.11 and 2.0). This allows tools like caniusepython3 to know a project's dependency on this package isn't blocking a port to Python 3.