### PR TITLE
Fixed bug where collapsing the sidebar caused incorrect offset CSS.

### DIFF
--- a/bootstrap_admin/static/bootstrap_admin/js/base.js
+++ b/bootstrap_admin/static/bootstrap_admin/js/base.js
@@ -28,7 +28,7 @@
   $(document).ready(function(){
     var show_hide_sidebar_menu = function () {
       hidden_menu = $('#sidebar-menu').data('hidden');
-      main_classes = 'col-xs-6 col-xs-offset-6 col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2';
+      main_classes = 'col-xs-8 col-xs-offset-4 col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2';
       if (hidden_menu) {
         $('.main').addClass(main_classes).removeClass('col-sm-12');
         $('.sidebar-menu').css('left', '0').data('hidden', false);


### PR DESCRIPTION
Upon upgrading to v0.4.1, I realized that the navbar no longer collapsed properly. It would seem this was caused by a mismatch in bootstrap formatting between base.js and base.html, because commit 393b33e edited only base.js. This resulted in the main content area not having the offset taken away when the navbar collapsed. The fix was just to update base.js to match the new base.html. I have also checked that those values are not referenced anywhere else in the project.